### PR TITLE
fix failed referencing theorem 2.5.1 in section 2.5

### DIFF
--- a/textbook/series.tex
+++ b/textbook/series.tex
@@ -578,7 +578,7 @@ other than zero, then the series diverges.
 We'll usually call this theorem the ``$n^{\nth}$ term test.''
 
 \begin{warning}
-  The converse of Theorem~\xrefn{thm-divergence-test} is {\em not\/}
+  The converse of Theorem~\xrefn{thm:divergence-test} is {\em not\/}
   true: even if $\ds\lim_{n\to\infty}a_n=0$, the series could diverge.
   For an example, see Section~\xrefn{section:harmonic-series}.
 \end{warning}


### PR DESCRIPTION
This pull request fixes a failed referencing in section 2.5.
![failed-referencing](https://f.cloud.github.com/assets/2360542/1274098/fbb0aff4-2d6f-11e3-96de-9d64b5c875a6.png)
