### PR TITLE
Attempted to improve readabality of the warning about the nth term test.

### DIFF
--- a/textbook/series.tex
+++ b/textbook/series.tex
@@ -579,14 +579,18 @@ We'll usually call this theorem the ``$n^{\nth}$ term test.''
 \begin{warning}
   The converse of Theorem~\xrefn{thm:divergence-test} is {\em not\/}
   true: even if $\ds\lim_{n\to\infty}a_n=0$, the series could diverge.
-  For an example, see Section~\xrefn{section:harmonic-series}.
-\end{warning}
-\sidenote{This is a \textit{very} common mistake: you might be tempted
+
+  This is a \textit{very} common mistake: you might be tempted
   to show that a series converges by showing
   $\ds\lim_{n\to\infty}a_n=0$, but that doesn't work.  The $n^{\nth}$
   term test \textbf{either says ``diverges!'' or says nothing at all.}
   It is not possible to show that anything converges by using the
-  $n^{\nth}$ term test.}  One analogy that can be helpful is think
+  $n^{\nth}$ term test.
+
+  For an example, see Section~\xrefn{section:harmonic-series}.
+\end{warning}
+
+One analogy that can be helpful is think
 about weather: whenever it is raining, it is cloudy.  Yet it is
 possible for there to be clouds, even on a rainless day.  \sidenote{We
   first introduced this idea on


### PR DESCRIPTION
I found the hanging '7' for the \sidenote a bit confusing, so attempted to improve the aesthetics.  I'm not sure if this is useful.
