### PR TITLE
fix typo in 7.2

### DIFF
--- a/textbook/remainders.tex
+++ b/textbook/remainders.tex
@@ -277,7 +277,7 @@ Essentially the same argument works for $\cos x$, which yields the following.
   $$
 \end{theorem}
 
-And similarly, the function is $e^x$ is \defnword{real analytic},
+And similarly, the function $e^x$ is \defnword{real analytic},
 meaning that the Taylor series for $e^x$ converges to $e^x$.
 \begin{theorem}\label{thm:exp-is-analytic}
   For all real numbers $x$,


### PR DESCRIPTION
This pull request fixed a typo in section 7.2. Actually I found this when I tried to reference the text for the definition of real analytic. I think it would be better if the text gives the definition.  
